### PR TITLE
Improve logging and quiet mode

### DIFF
--- a/vea/auth.py
+++ b/vea/auth.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from typing import List
+import logging
 
 from google_auth_oauthlib.flow import InstalledAppFlow
 
@@ -10,6 +11,8 @@ SCOPES = {
 
 TOKEN_DIR = Path(".credentials")
 CLIENT_SECRET = Path("credentials/client_secret.json")
+
+logger = logging.getLogger(__name__)
 
 
 def authorize(scopes: List[str]) -> None:
@@ -31,4 +34,4 @@ def authorize(scopes: List[str]) -> None:
         token_file = TOKEN_DIR / f"{s}_token.json"
         with open(token_file, "w") as f:
             f.write(creds.to_json())
-        print(f"Saved token to {token_file}")
+        logger.info("Saved token to %s", token_file)

--- a/vea/cli.py
+++ b/vea/cli.py
@@ -325,6 +325,7 @@ def prepare_event(
             slack=slack_data,
             bio=bio,
             prompt_path=prompt_path,
+            quiet=quiet,
             debug=debug,
         )
 
@@ -332,7 +333,7 @@ def prepare_event(
             print(summary)
 
         if slack_dm:
-            send_slack_dm(summary)
+            send_slack_dm(summary, quiet=quiet)
 
         if save_markdown or save_pdf:
             first_dt = datetime.fromisoformat(events[0]["start"])

--- a/vea/loaders/journals.py
+++ b/vea/loaders/journals.py
@@ -75,5 +75,9 @@ def load_journals(
             logger.warning(f"Skipping file {path} due to error: {e}", exc_info=e)
             continue
 
-    logger.info(f"Included {len(entries)} journal files from the past {journal_days} days.")
+    logger.debug(
+        "Included %d journal files from the past %d days.",
+        len(entries),
+        journal_days,
+    )
     return entries

--- a/vea/loaders/slack.py
+++ b/vea/loaders/slack.py
@@ -26,7 +26,11 @@ def calculate_lookback_start(now: datetime, workdays: int) -> datetime:
     if now.weekday() in (0, 1):
         while current.weekday() > 4:
             current -= timedelta(days=1)
-    logger.info(f"Fetching messages from: {current.isoformat()} to {now.isoformat()}")
+    logger.debug(
+        "Fetching messages from: %s to %s",
+        current.isoformat(),
+        now.isoformat(),
+    )
     return current
 
 
@@ -56,7 +60,7 @@ def replace_slack_mentions(text: str, user_map: Dict[str, str]) -> str:
 
 
 def build_user_map(client: WebClient) -> Dict[str, str]:
-    logger.info("Fetching Slack user list...")
+    logger.debug("Fetching Slack user list...")
     user_map = {}
     try:
         users = safe_slack_call(client.users_list)["members"]
@@ -151,7 +155,7 @@ def load_slack_messages(workdays_lookback: int = WORKDAYS_LOOKBACK) -> Dict[str,
     results = {}
 
     for conv_type in CHANNEL_TYPES:
-        logger.info(f"Fetching conversations of type: {conv_type}")
+        logger.debug("Fetching conversations of type: %s", conv_type)
         cursor = None
 
         while True:
@@ -177,7 +181,9 @@ def load_slack_messages(workdays_lookback: int = WORKDAYS_LOOKBACK) -> Dict[str,
                 channel_name = get_channel_name(channel, conv_type, user_map)
                 messages = fetch_messages_from_channel(client, channel, conv_type, oldest_ts, latest_ts, user_map)
                 if messages:
-                    logger.info(f"Collected {len(messages)} messages from {channel_name}")
+                    logger.debug(
+                        "Collected %d messages from %s", len(messages), channel_name
+                    )
                     results[channel_name] = messages
 
             cursor = response.get("response_metadata", {}).get("next_cursor")

--- a/vea/utils/llm_utils.py
+++ b/vea/utils/llm_utils.py
@@ -12,9 +12,12 @@ from .output_utils import truncate_prompt
 logger = logging.getLogger(__name__)
 
 
-def run_llm_prompt(prompt: str, model: Optional[str] = None) -> str:
+def run_llm_prompt(prompt: str, model: Optional[str] = None, *, quiet: bool = False) -> str:
 
-    logger.info(f"Sending collected data to {model}...")
+    if quiet:
+        logger.debug("Sending collected data to %s...", model)
+    else:
+        logger.info("Sending collected data to %s...", model)
 
     openai.api_key = os.getenv("OPENAI_API_KEY", os.getenv("OPENAI_KEY", ""))
     anthropic.api_key = os.getenv("ANTHROPIC_API_KEY", "")

--- a/vea/utils/slack_utils.py
+++ b/vea/utils/slack_utils.py
@@ -45,7 +45,7 @@ def markdown_to_mrkdwn(text: str) -> str:
     return text
 
 
-def send_slack_dm(message: str, *, token: Optional[str] = None) -> None:
+def send_slack_dm(message: str, *, token: Optional[str] = None, quiet: bool = False) -> None:
     """Send a direct message to the authenticated user."""
     token = token or os.environ.get("SLACK_TOKEN")
     if not token:
@@ -62,6 +62,7 @@ def send_slack_dm(message: str, *, token: Optional[str] = None) -> None:
             text=mrkdwn_message,
             blocks=[{"type": "section", "text": {"type": "mrkdwn", "text": mrkdwn_message}}],
         )
-        logger.info("Sent Slack DM to user")
+        if not quiet:
+            logger.info("Sent Slack DM to user")
     except SlackApiError as e:
         logger.warning(f"Failed to send Slack DM: {e.response['error']}")

--- a/vea/utils/summarization.py
+++ b/vea/utils/summarization.py
@@ -88,12 +88,12 @@ def summarize_daily(
 
 
 
-    if debug:
+    if debug and not quiet:
         logger.debug("========== BEGIN PROMPT ==========")
         logger.debug(prompt)
         logger.debug("=========== END PROMPT ===========")
 
-    return run_llm_prompt(prompt, model)
+    return run_llm_prompt(prompt, model, quiet=quiet)
 
 
 def summarize_weekly(
@@ -116,12 +116,12 @@ def summarize_weekly(
         bio=bio
     )
 
-    if debug:
+    if debug and not quiet:
         logger.debug("========== BEGIN PROMPT ==========")
         logger.debug(prompt)
         logger.debug("=========== END PROMPT ===========")
 
-    return run_llm_prompt(prompt, model)
+    return run_llm_prompt(prompt, model, quiet=quiet)
 
 
 def summarize_event_preparation(
@@ -133,6 +133,7 @@ def summarize_event_preparation(
     tasks: List,
     slack: Optional[Dict[str, List[Dict[str, str]]]] = None,
     bio: str = "",
+    quiet: bool = False,
     debug: bool = False,
     prompt_path: Optional[Path] = None,
 ) -> str:
@@ -149,9 +150,9 @@ def summarize_event_preparation(
         slack=json.dumps(slack, indent=2, default=str, ensure_ascii=False) if slack else "",
     )
 
-    if debug:
+    if debug and not quiet:
         logger.debug("========== BEGIN PROMPT ==========")
         logger.debug(prompt)
         logger.debug("=========== END PROMPT ===========")
 
-    return run_llm_prompt(prompt, model)
+    return run_llm_prompt(prompt, model, quiet=quiet)


### PR DESCRIPTION
## Summary
- upgrade logging with better messages
- honor `quiet` flag when calling summarization helpers and Slack DM
- trim info logs in loaders
- log token creation via logger

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840abd9e4c0832c8ceaa6102fcfd107