### PR TITLE
Add check-for-tasks command

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 Generate a personalized executive daily briefing, a weekly summary, or a last-minute briefing for a specific calendar event, all with a single command-line tool. Pulls in signals from your Google Calendar, Gmail, Todoist, local Markdown notes, and Slack – then condenses it all using AI into readable summaries.
 
+Supported commands:
+
+- `vea daily` – Generate a daily briefing
+- `vea weekly` – Summarize your week
+- `vea prepare-event` – Prepare for an upcoming meeting
+- `vea check-for-tasks` – Detect untracked or unfinished to-dos based on your recent activity
+
 
 ## Setup
 
@@ -125,6 +132,16 @@ Key options include:
 - `--journal-days` – Number of past journal days to include (default: 5)
 - `--slack-days` – Number of past days of Slack messages to load (default: 3)
 - `--slack-dm` – Send the output as a Slack DM to yourself
+
+### Check for forgotten tasks
+
+Use `vea check-for-tasks` to scan your journals, emails, Slack messages and Todoist for anything you may have missed.
+
+```bash
+vea check-for-tasks --journal-dir ~/Logseq/journals --todoist-lookback-days 10
+```
+
+This command detects untracked or unfinished to-dos based on your recent activity. Use `--todoist-lookback-days` to set how far back to include completed Todoist tasks (default: 14 days).
 
 ### AI Summary Engine
 

--- a/vea/cli/__init__.py
+++ b/vea/cli/__init__.py
@@ -3,7 +3,7 @@ from dotenv import load_dotenv
 
 from ..loaders import gcal, gmail, journals, extras, todoist, slack as slack_loader
 
-from . import auth, daily, weekly, prepare_event
+from . import auth, daily, weekly, prepare_event, check_for_tasks
 from .utils import _find_upcoming_events
 
 app = typer.Typer(help="Vea: Generate a personalized daily briefing or weekly summary.")
@@ -16,11 +16,13 @@ if hasattr(app, "add_typer"):
     app.add_typer(daily.app)
     app.add_typer(weekly.app)
     app.add_typer(prepare_event.app)
+    app.add_typer(check_for_tasks.app)
 else:  # Fallback for minimal Typer stubs in tests
     app.command("auth")(auth.auth_command)
     app.command("daily")(daily.generate)
     app.command("weekly")(weekly.generate_weekly_summary)
     app.command("prepare-event")(prepare_event.prepare_event)
+    app.command("check-for-tasks")(check_for_tasks.check_for_tasks)
 
 __all__ = [
     "app",

--- a/vea/cli/check_for_tasks.py
+++ b/vea/cli/check_for_tasks.py
@@ -1,0 +1,100 @@
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional
+
+import typer
+
+from ..loaders import gmail, journals, slack as slack_loader, todoist
+from ..utils.output_utils import resolve_output_path
+from ..utils.error_utils import enable_debug_logging, handle_exception
+from ..utils.summarization import summarize_check_for_tasks
+from ..utils.pdf_utils import convert_markdown_to_pdf
+from ..utils.generic_utils import check_required_directories
+
+app = typer.Typer()
+
+
+@app.command("check-for-tasks")
+def check_for_tasks(
+    journal_dir: Optional[Path] = typer.Option(None, help="Directory with Markdown journal files"),
+    journal_days: int = typer.Option(21, help="Number of past days of journals to include"),
+    gmail_labels: Optional[List[str]] = typer.Option(None, help="List of additional Gmail labels to fetch emails from"),
+    todoist_project: Optional[str] = typer.Option(None, help="Name of the Todoist project to filter tasks by"),
+    todoist_lookback_days: int = typer.Option(14, help="Number of days to look back for completed Todoist tasks"),
+    include_slack: bool = typer.Option(True, help="Include recent Slack messages"),
+    slack_days: int = typer.Option(
+        slack_loader.DEFAULT_DAYS_LOOKBACK,
+        help="Number of past days of Slack messages to load",
+    ),
+    save_markdown: bool = typer.Option(True, help="Save output to Markdown file"),
+    save_pdf: bool = typer.Option(False, help="Save output to PDF file"),
+    save_path: Optional[Path] = typer.Option(None, help="Custom file path or directory to save the output"),
+    prompt_file: Optional[Path] = typer.Option(None, help="Path to custom prompt file"),
+    model: str = typer.Option(
+        "gemini-2.5-pro-preview-05-06", help="Model to use for summarization (OpenAI, Google Gemini, or Anthropic)"
+    ),
+    skip_path_checks: bool = typer.Option(False, help="Skip checks for existence of input and output paths"),
+    debug: bool = typer.Option(False, help="Enable debug logging"),
+    quiet: bool = typer.Option(False, help="Suppress output to stdout"),
+) -> None:
+
+    if debug:
+        enable_debug_logging()
+
+    if not skip_path_checks:
+        check_required_directories(journal_dir, None, save_path)
+
+    prompt_path = prompt_file or Path(__file__).parent.parent / "prompts" / "check-for-tasks-default.prompt"
+    if not prompt_path.is_file():
+        typer.echo(f"Error: Default prompt file does not exist: {prompt_path}", err=True)
+        raise typer.Exit(code=1)
+
+    try:
+        journals_data = (
+            journals.load_journals(journal_dir, journal_days=journal_days)
+            if journal_dir
+            else []
+        )
+        emails = gmail.load_emails(datetime.today().date(), gmail_labels=gmail_labels)
+        slack_data = (
+            slack_loader.load_slack_messages(days_lookback=slack_days)
+            if include_slack
+            else {}
+        )
+        completed_tasks = todoist.load_completed_tasks(
+            lookback_days=todoist_lookback_days,
+            todoist_project=todoist_project or "",
+        )
+        future_tasks = todoist.load_future_tasks(todoist_project=todoist_project or "")
+        bio = os.getenv("BIO", "")
+
+        summary = summarize_check_for_tasks(
+            model=model,
+            journals=journals_data,
+            emails=emails,
+            completed_tasks=completed_tasks,
+            future_tasks=future_tasks,
+            slack=slack_data,
+            bio=bio,
+            prompt_path=prompt_path,
+            quiet=quiet,
+            debug=debug,
+        )
+
+        if not quiet:
+            print(summary)
+
+        if save_markdown or save_pdf:
+            today = datetime.today().date()
+            filename = f"{today.isoformat()}_tasks.md"
+            out_path = resolve_output_path(save_path, today, custom_filename=filename)
+
+        if save_markdown:
+            out_path.write_text(summary)
+
+        if save_pdf:
+            convert_markdown_to_pdf(summary, out_path.with_suffix(".pdf"), debug=debug)
+
+    except Exception as e:
+        handle_exception(e)

--- a/vea/prompts/check-for-tasks-default.prompt
+++ b/vea/prompts/check-for-tasks-default.prompt
@@ -1,0 +1,30 @@
+You are Vea, the Chief of Staff supporting a senior leader.
+
+> {bio}
+
+Analyze the collected data to find open tasks, follow-ups, or to-dos that may have been mentioned but were never completed or captured as Todoist tasks. Look for anything implied in journals, emails, or Slack messages that does not appear in the completed or future Todoist task lists.
+
+Return a concise bullet list of potential tasks the leader might have forgotten or not yet tracked.
+
+---
+
+### Collected Data
+
+== Journal Entries (JSON) ==
+{journals}
+
+== Emails (JSON) ==
+{emails}
+
+== Slack Messages (JSON) ==
+{slack}
+
+== Completed Todoist Tasks (JSON) ==
+{completed_tasks}
+
+== Future Todoist Tasks (JSON) ==
+{future_tasks}
+
+---
+
+Now list the outstanding or uncaptured tasks as bullet points.

--- a/vea/utils/summarization.py
+++ b/vea/utils/summarization.py
@@ -12,6 +12,7 @@ APP_ROOT = Path(__file__).resolve().parents[2]
 PROMPT_TEMPLATE_PATH = APP_ROOT / "vea" / "prompts" / "daily-default.prompt"
 APP_WEEKLY_PROMPT_PATH = APP_ROOT / "vea/prompts/weekly-default.prompt"
 APP_PREPARE_EVENT_PROMPT_PATH = APP_ROOT / "vea/prompts/prepare-event.prompt"
+APP_CHECK_FOR_TASKS_PROMPT_PATH = APP_ROOT / "vea/prompts/check-for-tasks-default.prompt"
 
 
 def load_prompt_template(path: Optional[Path] = None) -> str:
@@ -147,6 +148,38 @@ def summarize_event_preparation(
         extras=json.dumps(extras, indent=2, default=str, ensure_ascii=False),
         emails=json.dumps(emails, indent=2, default=str, ensure_ascii=False),
         tasks=json.dumps(tasks, indent=2, default=str, ensure_ascii=False),
+        slack=json.dumps(slack, indent=2, default=str, ensure_ascii=False) if slack else "",
+    )
+
+    if debug and not quiet:
+        logger.debug("========== BEGIN PROMPT ==========")
+        logger.debug(prompt)
+        logger.debug("=========== END PROMPT ===========")
+
+    return run_llm_prompt(prompt, model, quiet=quiet)
+
+
+def summarize_check_for_tasks(
+    model: str,
+    journals: List,
+    emails: Dict,
+    completed_tasks: List,
+    future_tasks: List,
+    slack: Optional[Dict[str, List[Dict[str, str]]]] = None,
+    bio: str = "",
+    quiet: bool = False,
+    debug: bool = False,
+    prompt_path: Optional[Path] = None,
+) -> str:
+    """Identify potentially forgotten or uncaptured tasks."""
+
+    template = load_prompt_template(prompt_path or APP_CHECK_FOR_TASKS_PROMPT_PATH)
+    prompt = template.format(
+        bio=bio,
+        journals=json.dumps(journals, indent=2, default=str, ensure_ascii=False),
+        emails=json.dumps(emails, indent=2, default=str, ensure_ascii=False),
+        completed_tasks=json.dumps(completed_tasks, indent=2, default=str, ensure_ascii=False),
+        future_tasks=json.dumps(future_tasks, indent=2, default=str, ensure_ascii=False),
         slack=json.dumps(slack, indent=2, default=str, ensure_ascii=False) if slack else "",
     )
 


### PR DESCRIPTION
## Summary
- add `check-for-tasks` CLI command
- support loading completed and future Todoist tasks
- add summarization helper and prompt
- document new command and options in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68415fb6b3a8832cbe4ce75c66205aa4