### PR TITLE
Support OpenAI responses API

### DIFF
--- a/vea/utils/llm_utils.py
+++ b/vea/utils/llm_utils.py
@@ -75,7 +75,7 @@ def run_llm_prompt(prompt: str, model: Optional[str] = None, *, quiet: bool = Fa
                     kwargs["temperature"] = 0.3
                     kwargs["max_tokens"] = 16384
                 response = client.responses.create(**kwargs)
-                return response.response.strip()
+                return response.output_text.strip()
 
             kwargs = {
                 "model": model,


### PR DESCRIPTION
## Summary
- add helper `is_responses_model` to detect models that require the Responses API
- update `run_llm_prompt` to use Responses API when needed

## Testing
- `ruff check .` *(fails: F401 errors in unrelated files)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849896f71c4832c890ae86a71b5bf6c