### PR TITLE
Preserve Slack channels in embedding results

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ You can choose between OpenAI, Anthropic (Claude), or Google Gemini models.
 
 ### Embeddings-based retrieval
 
-Add `--use-embeddings` to `vea daily` or `vea prepare-event` to index your notes, emails and Slack messages with FAISS. Index files are stored in `~/.vea/indexes`. Journals can be split into bullet points with `--outliner-mode`. Use the `--topk-*` options to control how many passages are returned (default 5 each). Retrieved passages remain structured JSON objects so the prompts stay valid JSON.
+Add `--use-embeddings` to `vea daily` or `vea prepare-event` to index your notes, emails and Slack messages with FAISS. Index files are stored in `~/.vea/indexes`. Journals can be split into bullet points with `--outliner-mode`. Use the `--topk-*` options to control how many passages are returned (default 5 each). Retrieved passages remain structured JSON objects so the prompts stay valid JSON. When Slack snippets are retrieved through embeddings they are still grouped by channel or DM.
 
 ### Vea Instructions in Today’s Journal
 


### PR DESCRIPTION
## Summary
- include channel name in Slack messages and replies
- retain channel field when building slack document embeddings
- regroup embedding hits by channel before rendering prompts
- mention channel-grouping behaviour in README
- update embedding summarization test for grouped Slack results

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858e3c2d134832cb2478545c1e154c1